### PR TITLE
Alternative box highlighting and improved border highlighting

### DIFF
--- a/WaystoneHighlight.cs
+++ b/WaystoneHighlight.cs
@@ -10,6 +10,8 @@ using System.Drawing;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Eventing.Reader;
+using RectangleF = ExileCore2.Shared.RectangleF;
+using ExileCore2.Shared.Nodes;
 
 
 namespace WaystoneHighlight;
@@ -210,7 +212,7 @@ public class WaystoneHighlight : BaseSettingsPlugin<WaystoneHighlightSettings>
                 // Frame
                 if (hasBannedMod)
                 {
-                    Graphics.DrawFrame(bbox, Settings.Graphics.BannedBorderColor, Settings.Graphics.BannedBorderThickness.Value);
+                    DrawBorderHighlight(bbox, Settings.Graphics.BannedBorderColor, Settings.Graphics.BannedBorderThickness.Value);
                 }
                 else
                 {
@@ -218,12 +220,12 @@ public class WaystoneHighlight : BaseSettingsPlugin<WaystoneHighlightSettings>
                     {
                         if (prefixCount < 3 && !isCorrupted)
                         {
-                            Graphics.DrawFrame(bbox, Settings.Graphics.CraftBorderColor, Settings.Graphics.CraftBorderThickness.Value);
+                            DrawBorderHighlight(bbox, Settings.Graphics.CraftBorderColor, Settings.Graphics.CraftBorderThickness.Value);
 
                         }
                         else if (score >= Settings.Score.MinimumRunHighlightScore)
                         {
-                            Graphics.DrawFrame(bbox, Settings.Graphics.RunBorderColor, Settings.Graphics.RunBorderThickness.Value);
+                            DrawBorderHighlight(bbox, Settings.Graphics.RunBorderColor, Settings.Graphics.RunBorderThickness.Value);
                         }
                     }
                 }
@@ -261,6 +263,15 @@ public class WaystoneHighlight : BaseSettingsPlugin<WaystoneHighlightSettings>
 
             }
         }
+    }
+    private void DrawBorderHighlight(RectangleF rect, ColorNode color, int thickness) {
+        int scale = thickness - 1;
+        int innerX = (int)rect.X + 1 + (int)(0.5 * scale);
+        int innerY = (int)rect.Y + 1 + (int)(0.5 * scale);
+        int innerWidth = (int)rect.Width - 1 - scale;
+        int innerHeight = (int)rect.Height - 1 - scale;
+        RectangleF scaledFrame = new RectangleF(innerX, innerY, innerWidth, innerHeight);
+        Graphics.DrawFrame(scaledFrame, color, thickness);
     }
 
 

--- a/WaystoneHighlight.cs
+++ b/WaystoneHighlight.cs
@@ -212,20 +212,44 @@ public class WaystoneHighlight : BaseSettingsPlugin<WaystoneHighlightSettings>
                 // Frame
                 if (hasBannedMod)
                 {
-                    DrawBorderHighlight(bbox, Settings.Graphics.BannedBorderColor, Settings.Graphics.BannedBorderThickness.Value);
-                }
+                    switch (Settings.Graphics.BannedHightlightStyle) 
+                    {
+                        case 1:
+                            DrawBorderHighlight(bbox, Settings.Graphics.BannedHighlightColor, Settings.Graphics.BorderHighlight.BannedBorderThickness);
+                            break;
+                        case 2:
+                            DrawBoxHighlight(bbox, Settings.Graphics.BannedHighlightColor, Settings.Graphics.BoxHighlight.BannedBoxRounding.Value);
+                            break;
+                    }
+                } 
                 else
                 {
                     if (score >= Settings.Score.MinimumCraftHighlightScore)
                     {
                         if (prefixCount < 3 && !isCorrupted)
                         {
-                            DrawBorderHighlight(bbox, Settings.Graphics.CraftBorderColor, Settings.Graphics.CraftBorderThickness.Value);
+                            switch (Settings.Graphics.CraftHightlightStyle)
+                            {
+                                case 1:
+                                    DrawBorderHighlight(bbox, Settings.Graphics.CraftHighlightColor, Settings.Graphics.BorderHighlight.CraftBorderThickness.Value);
+                                    break;
+                                case 2:
+                                    DrawBoxHighlight(bbox, Settings.Graphics.CraftHighlightColor, Settings.Graphics.BoxHighlight.CraftBoxRounding.Value);
+                                    break;
+                            }
 
                         }
                         else if (score >= Settings.Score.MinimumRunHighlightScore)
                         {
-                            DrawBorderHighlight(bbox, Settings.Graphics.RunBorderColor, Settings.Graphics.RunBorderThickness.Value);
+                            switch (Settings.Graphics.RunHightlightStyle) 
+                            {
+                                case 1:
+                                    DrawBorderHighlight(bbox, Settings.Graphics.RunHighlightColor, Settings.Graphics.BorderHighlight.RunBorderThickness.Value);
+                                    break;
+                                case 2:
+                                    DrawBoxHighlight(bbox, Settings.Graphics.RunHighlightColor, Settings.Graphics.BoxHighlight.RunBoxRounding.Value);
+                                    break;
+                            }
                         }
                     }
                 }
@@ -235,36 +259,38 @@ public class WaystoneHighlight : BaseSettingsPlugin<WaystoneHighlightSettings>
 
                     // Stats
                     // SetTextScale doesn't scale well we need to change origin point or add x:y placement modifications depending on scale
-                    using (Graphics.SetTextScale(Settings.Graphics.QRFontSizeMultiplier))
+                    using (Graphics.SetTextScale(Settings.Graphics.FontSize.QRFontSizeMultiplier))
                     {
                         Graphics.DrawText(iir.ToString(), new Vector2(bbox.Left + 5, bbox.Top), ExileCore2.Shared.Enums.FontAlign.Left);
-                        Graphics.DrawText(iiq.ToString(), new Vector2(bbox.Left + 5, bbox.Top + 2 + (10 * Settings.Graphics.QRFontSizeMultiplier)), ExileCore2.Shared.Enums.FontAlign.Left);
+                        Graphics.DrawText(iiq.ToString(), new Vector2(bbox.Left + 5, bbox.Top + 2 + (10 * Settings.Graphics.FontSize.QRFontSizeMultiplier)), ExileCore2.Shared.Enums.FontAlign.Left);
                         if (extraRareMod)
                         {
-                            Graphics.DrawText("+1", new Vector2(bbox.Left + 5, bbox.Top + 4 + (20 * Settings.Graphics.QRFontSizeMultiplier)), ExileCore2.Shared.Enums.FontAlign.Left);
+                            Graphics.DrawText("+1", new Vector2(bbox.Left + 5, bbox.Top + 4 + (20 * Settings.Graphics.FontSize.QRFontSizeMultiplier)), ExileCore2.Shared.Enums.FontAlign.Left);
                         }
                     }
 
                     // Affixes count
                     // SetTextScale doesn't scale well we need to change origin point or add x:y placement modifications depending on scale
-                    using (Graphics.SetTextScale(Settings.Graphics.PrefSuffFontSizeMultiplier))
+                    using (Graphics.SetTextScale(Settings.Graphics.FontSize.PrefSuffFontSizeMultiplier))
                     {
                         Graphics.DrawText(prefixCount.ToString(), new Vector2(bbox.Right - 5, bbox.Top), ExileCore2.Shared.Enums.FontAlign.Right);
-                        Graphics.DrawText(suffixCount.ToString(), new Vector2(bbox.Right - 5, bbox.Top + 2 + (10 * Settings.Graphics.PrefSuffFontSizeMultiplier)), ExileCore2.Shared.Enums.FontAlign.Right);
+                        Graphics.DrawText(suffixCount.ToString(), new Vector2(bbox.Right - 5, bbox.Top + 2 + (10 * Settings.Graphics.FontSize.PrefSuffFontSizeMultiplier)), ExileCore2.Shared.Enums.FontAlign.Right);
                     }
 
                     // Score
                     // SetTextScale doesn't scale well we need to change origin point or add x:y placement modifications depending on scale
-                    using (Graphics.SetTextScale(Settings.Graphics.ScoreFontSizeMultiplier))
+                    using (Graphics.SetTextScale(Settings.Graphics.FontSize.ScoreFontSizeMultiplier))
                     {
-                        Graphics.DrawText(score.ToString(), new Vector2(bbox.Left + 5, bbox.Bottom - 5 - (15 * Settings.Graphics.ScoreFontSizeMultiplier)), ExileCore2.Shared.Enums.FontAlign.Left);
+                        Graphics.DrawText(score.ToString(), new Vector2(bbox.Left + 5, bbox.Bottom - 5 - (15 * Settings.Graphics.FontSize.ScoreFontSizeMultiplier)), ExileCore2.Shared.Enums.FontAlign.Left);
                     }
                 }
 
             }
         }
     }
-    private void DrawBorderHighlight(RectangleF rect, ColorNode color, int thickness) {
+
+    private void DrawBorderHighlight(RectangleF rect, ColorNode color, int thickness)
+    {
         int scale = thickness - 1;
         int innerX = (int)rect.X + 1 + (int)(0.5 * scale);
         int innerY = (int)rect.Y + 1 + (int)(0.5 * scale);
@@ -274,5 +300,13 @@ public class WaystoneHighlight : BaseSettingsPlugin<WaystoneHighlightSettings>
         Graphics.DrawFrame(scaledFrame, color, thickness);
     }
 
-
+    private void DrawBoxHighlight(RectangleF rect, ColorNode color, int rounding)
+    {
+        int innerX = (int)rect.X + 1 + (int)(0.5 * rounding);
+        int innerY = (int)rect.Y + 1 + (int)(0.5 * rounding);
+        int innerWidth = (int)rect.Width - 1 - rounding;
+        int innerHeight = (int)rect.Height - 1 - rounding;
+        RectangleF scaledBox = new RectangleF(innerX, innerY, innerWidth, innerHeight);
+        Graphics.DrawBox(scaledBox, color, rounding);
+    }
 }

--- a/WaystoneHighlightSettings.cs
+++ b/WaystoneHighlightSettings.cs
@@ -71,36 +71,68 @@ public class ScoreSettings
 }
 
 [Submenu(CollapsedByDefault = false)]
-public class GraphicSettings
-{
-//BORDER COLOR
-   [Menu("Runnable Waystone Border Color", "Color of the Border of Runnable Waystones")]
-    public ColorNode RunBorderColor { get; set; } = new ColorNode(Color.Green);
+public class GraphicSettings {
+    //HIGHLIGHT COLOR
+    [Menu("Runnable Waystone Highlight Color", "Highlight color for Runnable Waystones")]
+    public ColorNode RunHighlightColor { get; set; } = new ColorNode(Color.Green);
 
-   [Menu("Craftable Waystone Border Color", "Color of the Border of Craftable Waystones")]
-    public ColorNode CraftBorderColor { get; set; } = new ColorNode(Color.Yellow);
+    [Menu("Craftable Waystone Highlight Color", "Highlight color for Craftable Waystones")]
+    public ColorNode CraftHighlightColor { get; set; } = new ColorNode(Color.Yellow);
 
-   [Menu("Banned Modifiers Waystone Border Color", "Color of the Border of Waystones with Banned Modifiers")]
-    public ColorNode BannedBorderColor { get; set; } = new ColorNode(Color.Red);
+    [Menu("Banned Modifiers Waystone Highlight Color", "Highlight color for Waystones with Banned Modifiers")]
+    public ColorNode BannedHighlightColor { get; set; } = new ColorNode(Color.Red);
 
-//BORDER THICKNESS
-   [Menu("Runnable Waystone Border Thickness", "Thickness of the Border of Runnable Waystones")]
+    //HIGHLIGHT STYLE
+    [Menu("Runnable Waystone Highlight Style", "1 = Border; 2 = Filled box/dot")]
+    public RangeNode<int> RunHightlightStyle { get; set; } = new RangeNode<int>(1, 1, 2);
+    [Menu("Craftable Waystone Highlight Style", "1 = Broder; 2 = Filled box/dot")]
+    public RangeNode<int> CraftHightlightStyle { get; set; } = new RangeNode<int>(1, 1, 2);
+    [Menu("Banned Waystone Highlight Style", "1 = Border; 2 = Filled box/dot")]
+    public RangeNode<int> BannedHightlightStyle { get; set; } = new RangeNode<int>(1, 1, 2);
+
+    [Menu("Border Highlight Thickness Settings")]
+    public BorderHighlightSettings BorderHighlight { get; set; } = new BorderHighlightSettings();
+    [Menu("Box Highlight Rounding Settings")]
+    public BoxHighlightSettings BoxHighlight { get; set; } = new BoxHighlightSettings();
+    [Menu("Font Size Settings")]
+    public FontSizeSettings FontSize { get; set; } = new FontSizeSettings();
+}
+
+[Submenu(CollapsedByDefault = true)]
+public class BorderHighlightSettings {
+    //BORDER THICKNESS
+    [Menu("Runnable Waystone Border Thickness", "Thickness of the Border of Runnable Waystones")]
     public RangeNode<int> RunBorderThickness { get; set; } = new RangeNode<int>(1, 1, 5);
-  
-   [Menu("Craftable Waystone Border Thickness", "Thickness of the Border of Craftable Waystones")]
+
+    [Menu("Craftable Waystone Border Thickness", "Thickness of the Border of Craftable Waystones")]
     public RangeNode<int> CraftBorderThickness { get; set; } = new RangeNode<int>(1, 1, 5);
-  
-   [Menu("Banned Modifiers Waystone Border Thickness", "Thickness of the Border of Waystones with Banned Modifiers")]
+
+    [Menu("Banned Modifiers Waystone Border Thickness", "Thickness of the Border of Waystones with Banned Modifiers")]
     public RangeNode<int> BannedBorderThickness { get; set; } = new RangeNode<int>(1, 1, 5);
+}
 
+[Submenu(CollapsedByDefault = true)]
+public class BoxHighlightSettings {
+    //BOX ROUNDING
+    [Menu("Runnable Waystone Box Rounding", "Rounding of the Box for Runnable Waystones")]
+    public RangeNode<int> RunBoxRounding { get; set; } = new RangeNode<int>(1, 1, 60);
 
-//FONT SIZE (Needs modifications as text scales from origin point and doesn't change position accordingly)
-   [Menu("Waystone Quantity+Rarity Font Size", "Size of the global font for Waystone Scores")]
+    [Menu("Craftable Waystone Box Rounding", "Rounding of the Box for Craftable Waystones")]
+    public RangeNode<int> CraftBoxRounding { get; set; } = new RangeNode<int>(1, 1, 60);
+
+    [Menu("Banned Modifiers Waystone Box Rounding", "Rounding of the Box for Waystones with Banned Modifiers")]
+    public RangeNode<int> BannedBoxRounding { get; set; } = new RangeNode<int>(1, 1, 60);
+}
+
+[Submenu(CollapsedByDefault = true)]
+public class FontSizeSettings {
+    //FONT SIZE (Needs modifications as text scales from origin point and doesn't change position accordingly)
+    [Menu("Waystone Quantity+Rarity Font Size", "Size of the global font for Waystone Scores")]
     public RangeNode<float> QRFontSizeMultiplier { get; set; } = new RangeNode<float>(1.0f, 0.5f, 2f);
 
-  [Menu("Waystone Score Font Size", "Size of the global font for Waystone Scores")]
+    [Menu("Waystone Score Font Size", "Size of the global font for Waystone Scores")]
     public RangeNode<float> ScoreFontSizeMultiplier { get; set; } = new RangeNode<float>(1.0f, 0.5f, 2f);
 
-  [Menu("Waystone Prefix+Suffix Font Size", "Size of the global font for Affix Count")]
+    [Menu("Waystone Prefix+Suffix Font Size", "Size of the global font for Affix Count")]
     public RangeNode<float> PrefSuffFontSizeMultiplier { get; set; } = new RangeNode<float>(1.0f, 0.5f, 2f);
 }


### PR DESCRIPTION
* border highlight is drawn with the smallest possible gap to neighboring highlights
  * as thickness is increased, border will only scale inwards to avoid overlap
* added new alternative box highlighting 
  * box highlighting supports rounding scaling from full rectangle to small central dot
* added settings for box highlighting and selecting highlighting styles
* reorganized thickness, rounding and font size settings into submenus